### PR TITLE
Fix readFileSync only returns byte buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function ({ theme, options = {} }) {
 
         return compileString(
           // TODO (boen): 未解析 file query
-          loader(FS.readFileSync(scssFilePath), {
+          loader(FS.readFileSync(scssFilePath, {encoding: 'utf8'}), {
             ...semiSemiLoaderOptions,
             ...options,
             variables: convertMapToString(options.variables || {}),

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function loader(source, options) {
 
   const shouldInject = source.includes("semi-base");
 
-  let fileStr = source;
+  let fileStr = source.toString('utf8');
 
   let componentVariables;
 

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function loader(source, options) {
     try {
       const regex =
         /(@import '.\/variables.scss';?|@import ".\/variables.scss";?)/g;
-      const fileSplit = source.split(regex).filter((item) => Boolean(item));
+      const fileSplit = fileStr.split(regex).filter((item) => Boolean(item));
       if (fileSplit.length > 1) {
         fileSplit.splice(fileSplit.length - 1, 0, localImport);
         fileStr = fileSplit.join("");


### PR DESCRIPTION
FS.readFileSync has no encoding options, so that it returns byte buffer.
This bug prevents the code to read the SCSS file correctly to add the import statement in the loader() function.
So I just converted it to string 