### PR TITLE
Fix error while including SCSS on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ module.exports = function ({ theme, options = {} }) {
     enforce: "post",
     load(id) {
       let filePath = normalizePath(id);
-
+      if (options.include){
+        options.include = normalizePath(options.include);
+      }
       // https://github.com/DouyinFE/semi-design/blob/main/packages/semi-webpack/src/semi-webpack-plugin.ts#L83
       if (
         /@douyinfe\/semi-(ui|icons|foundation)\/lib\/.+\.css$/.test(filePath)


### PR DESCRIPTION
Just a minor fix. 
SCSS requires the path to contain only forward slashes `/`, while Windows use paths with back slashes, e.g. `D:\scss\local.scss`. Therefore, we need to call `normalizePath()` on options.include to ensure this is always correct on all OS
