### PR TITLE
fix: component tokens didn't take effect under vite 3.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function loader(source, options) {
   let componentVariables;
 
   try {
-    componentVariables = resolve.sync(this.context, `${theme}/scss/local.scss`);
+    componentVariables = require.resolve(`${theme}/scss/local.scss`);
   } catch (e) {}
 
   if (options.include || options.variables || componentVariables) {


### PR DESCRIPTION
`resolve.sync` always failed Since `resolve` is undefined. Tested under vite3.2